### PR TITLE
Update SIINTEC template: modify author command to use a comma instead…

### DIFF
--- a/main.pdf
+++ b/main.pdf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:12ed7f8b1a6f18605eeebe304df0a3c46fff692488f9d341a7bf0d56dda1cc2e
+oid sha256:81c3d77e15ca4798aa544f5eaba03a90fc15b1ec4a862cbc65c787eb0b974f49
 size 1004785

--- a/siintec.cls
+++ b/siintec.cls
@@ -204,6 +204,7 @@
 }
 
 % Command for setting author with optional affiliation number
+\renewcommand\Authand{, }
 \renewcommand\Authands{, }
 \newcommand{\siintecauthor}[2][]{%
   \author[#1]{\siintecauthorfont #2\vspace*{-0.55em}}


### PR DESCRIPTION
… of 'and'  for improved formatting in siintec.cls even when have only 2 authors; update PDF file hash.